### PR TITLE
Add tests and fix manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,30 +1,4 @@
-# This file details all external dependencies required by your skill. If your skill does
-# not require any dependencies, please delete this file before submitting a pull request.
-#
-# dependencies:
-#   # Pip dependencies on PyPI
-#   python:
-#     - requests
-#     - gensim
-#
-#   # Install packages with the system package manager
-#   # This searches for the provided executable and uses the package names
-#   system:
-#     # For simple packages, this is all that is necessary
-#     all: pianobar piano-dev
-#
-#     # If the package has a certain name on a different platform:
-#     pkcon: pianobar libpiano-dev  # For the mycroft platform
-#     apt-get: pianobar libpiano-dev  # For Ubuntu/Debian
-#
-#   # Require certain executables to be in the PATH for the install to succeed
-#   exes:
-#     - pianobar
-#
-#   # Require the installation of other skills before installing this skill
-#   skills:
-#     - my-other-skill
-
-python:
-  - pint
-  - sympy
+dependencies:
+  python:
+    - pint
+    - sympy

--- a/test/intent/001.unit.conversion.json
+++ b/test/intent/001.unit.conversion.json
@@ -1,0 +1,9 @@
+{
+    "utterance": "how many feet are in a meter",
+    "intent_type": "convert.units.intent",
+    "intent": {
+        "unitfrom": "feet",
+        "unitto": "meter"
+    },
+    "expected_dialog": "conversion"
+}

--- a/test/intent/002.unit.unknown.json
+++ b/test/intent/002.unit.unknown.json
@@ -1,0 +1,9 @@
+{
+    "utterance": "how many meters in a leap year",
+    "intent_type": "convert.units.intent",
+    "intent": {
+        "unitfrom": "meters",
+        "unitto": "leap year"
+    },
+    "expected_dialog": "unknownUnitError"
+}

--- a/test/intent/003.dimensionality.error.json
+++ b/test/intent/003.dimensionality.error.json
@@ -1,0 +1,9 @@
+{
+    "utterance": "how many hertz in a yard",
+    "intent_type": "convert.units.intent",
+    "intent": {
+        "unitfrom": "hertz",
+        "unitto": "yard"
+    },
+    "expected_dialog": "dimensionalityError"
+}


### PR DESCRIPTION
Adds a single integration test for each primary pathway.
Fixes `manifest.yml` to ensure dependencies are installed correctly.